### PR TITLE
ask-nypl-phone-numbers

### DIFF
--- a/emails/delivery.twig
+++ b/emails/delivery.twig
@@ -56,6 +56,6 @@
 <p>Dear {{ data.patronName }},</p>
     <p>The recent request you placed for materials for electronic delivery has been received. Soon, you will receive a notification from the Library’s ILL email address (<a href="mailto:interlibraryloan@nypl.org">interlibraryloan@nypl.org</a>). The subject of the email contains the requested item's barcode, and you will see a "oc.lc" link and password to retrieve document. Once you enter the password, your download will begin automatically.
 </p>
-    <p>If you would like to cancel your request, or if you have further questions, please contact 917-275-6975 (917-ASK-NYPL).</p>
+    <p>If you would like to cancel your request, or if you have further questions, please call 917-ASK-NYPL (917-275-6975).</p>
 </body>
 </html>


### PR DESCRIPTION
Courtney M's comments: Messages on confirmation pages and the like go this route, putting the 'branded' name/number first followed by the digits.
"If you would like to cancel your request, or if you have further questions, please call 917-ASK-NYPL (917-275-6975)."