### PR TITLE
ask-nypl-phone-numbers

### DIFF
--- a/emails/holdfail.twig
+++ b/emails/holdfail.twig
@@ -59,7 +59,7 @@
     <strong>Author</strong>: {{ data.author }}<br/>
     <strong>Barcode</strong>: {{ data.barcode }}
 </p>
-<p>Please try again or contact 917-ASK-NYPL (917-275-6975).</p>
+<p>Please try again or call 917-ASK-NYPL (917-275-6975).</p>
 <p>The New York Public Library</p>
 </body>
 </html>


### PR DESCRIPTION
Courtney M's comments: Messages on confirmation pages and the like go this route, putting the 'branded' name/number first followed by the digits. 
"If you would like to cancel your request, or if you have further questions, please call 917-ASK-NYPL (917-275-6975)."