### PR TITLE
ask-nypl-phone-numbers

### DIFF
--- a/emails/holdsuccess.twig
+++ b/emails/holdsuccess.twig
@@ -71,7 +71,7 @@
         <td>{{ data.pickupLocation }}</td>
     </tbody>
 </table>
-<p>If you would like to cancel your request, or if you have further questions, please contact 917-275-6975 (917-ASK-NYPL).
+<p>If you would like to cancel your request, or if you have further questions, please call 917-ASK-NYPL (917-275-6975).
 </p>
 <p>The New York Public Library</p>
 </body>


### PR DESCRIPTION
Courtney M's comments: Messages on confirmation pages and the like go this route, putting the 'branded' name/number first followed by the digits. 
"If you would like to cancel your request, or if you have further questions, please call 917-ASK-NYPL (917-275-6975)."