### PR TITLE
Fixes #34 add Error to HoldRequestService patch on failure

### DIFF
--- a/src/HoldRequestResultConsumerListener.php
+++ b/src/HoldRequestResultConsumerListener.php
@@ -73,7 +73,8 @@ class HoldRequestResultConsumerListener extends Listener
         $holdRequestService = HoldRequestClient::patchHoldRequestById(
             $holdRequestResult->getHoldRequestId(),
             true,
-            $holdRequestResult->isSuccess()
+            $holdRequestResult->isSuccess(),
+            $holdRequestResult->getError()
         );
 
         APILogger::addDebug('Hold Request Service Patched', (array)$holdRequestService);

--- a/src/OAuthClient/HoldRequestClient.php
+++ b/src/OAuthClient/HoldRequestClient.php
@@ -2,6 +2,7 @@
 namespace NYPL\HoldRequestResultConsumer\OAuthClient;
 
 use NYPL\HoldRequestResultConsumer\Model\DataModel\HoldRequest;
+use NYPL\HoldRequestResultConsumer\Model\DataModel\StreamData\Error;
 use NYPL\HoldRequestResultConsumer\Model\Exception\NonRetryableException;
 use NYPL\Starter\APILogger;
 use NYPL\Starter\Config;
@@ -108,9 +109,10 @@ class HoldRequestClient extends APIClient
      * @param int $holdRequestId
      * @param bool $processed
      * @param bool $success
+     * @param Error $error
      * @return null|HoldRequest
      */
-    public static function patchHoldRequestById(int $holdRequestId, bool $processed, bool $success)
+    public static function patchHoldRequestById(int $holdRequestId, bool $processed, bool $success, Error $error)
     {
         self::validateRequestId($holdRequestId);
         self::validateProcessed($processed);
@@ -119,6 +121,10 @@ class HoldRequestClient extends APIClient
         $url = Config::get('API_HOLD_REQUEST_URL') . '/' . $holdRequestId;
 
         $body = ["processed" => $processed, "success" => $success];
+
+        if (!$success) {
+            array_push($body, ["error" => $error->getMessage()]);
+        }
 
         APILogger::addDebug('Patching hold request by id', array($url, $body));
 


### PR DESCRIPTION
Code change to send along the Error->getMessage() along to the HoldRequestService if success is false. The message from either the HoldRequestConsumer or RecapHoldRequestConsumer should be communicated back on the PATCH operation, recorded by the HoldRequestService and passed on to the JobService API.