### PR TITLE
Merge deployment hotfixes to QA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
 node_js:
 - 10
 install:
+- echo "Node version is $TRAVIS_NODE_VERSION"
 - npm install
 - composer install
 script:
@@ -29,7 +30,7 @@ deploy:
   script: "./scripts/travis-deploy.sh $ENVIRONMENT_NAME"
   on:
     all_branches: true
-    condition: "$TRAVIS_BRANCH =~ ^(development|qa|production)$"
+    condition: "$ENVIRONMENT_NAME =~ ^(development|qa|production)$"
 after_deploy: echo "Successfully executed deploy trigger for $TRAVIS_BRANCH"
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language:
 php:
 - 7.1
 install:
+- nvm use
 - npm install
 - composer install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ after_success:
 - vendor/bin/phpcs -n --standard=PSR1,PSR2 src/
 - vendor/bin/phpcbf src/
 before_deploy:
-- nvm use
+- nvm install
 - echo "All unit tests passed; Preparing to deploy $TRAVIS_BRANCH"
 deploy:
 - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ language:
 - node_js
 php:
 - 7.1
-node_js:
-- 10
 install:
-- echo "Node version is $TRAVIS_NODE_VERSION"
 - npm install
 - composer install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ language:
 - node_js
 php:
 - 7.1
+node_js:
+- 10
 install:
-- nvm use
 - npm install
 - composer install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ after_success:
 - vendor/bin/phpcs -n --standard=PSR1,PSR2 src/
 - vendor/bin/phpcbf src/
 before_deploy:
+- nvm use
 - echo "All unit tests passed; Preparing to deploy $TRAVIS_BRANCH"
 deploy:
 - provider: script

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "PHP Lambda processing Hold Request Results and send e-mail notificaitons.",
   "main": "listener.js",
   "scripts": {
-    "deploy-development": "./node_modules/.bin/node-lambda deploy -e development -f config/var_dev.env -S config/event_sources_dev.json -b --profile nypl-sandbox --role arn:aws:iam::224280085904:role/lambda_basic_execution",
+    "deploy-development": "./node_modules/.bin/node-lambda deploy -e development -f config/var_development.env -S config/event_sources_development.json -b --profile nypl-sandbox --role arn:aws:iam::224280085904:role/lambda_basic_execution",
     "deploy-qa": "./node_modules/.bin/node-lambda deploy -e qa -f config/var_qa.env -S config/event_sources_qa.json -b --profile nypl-digital-dev --role arn:aws:iam::946183545209:role/lambda-full-access",
     "deploy-production": "./node_modules/.bin/node-lambda deploy -e production -f config/var_production.env -S config/event_sources_production.json --profile nypl-digital-dev --role arn:aws:iam::946183545209:role/lambda-full-access",
     "test-event": "./node_modules/.bin/node-lambda run -f config/var_app -j events/kinesis_hold_request_success.json -x events/context.json"

--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -22,7 +22,8 @@ DEPLOY_CMD=$(cat package.json | jq ".scripts | .\"deploy-$ENVIRONMENT_NAME\"" --
 # known to be set in travis:
 DEPLOY_CMD=$(echo "$DEPLOY_CMD" | sed "s/ --profile [a-z-]*/ -a \$AWS_ACCESS_KEY_ID_$ENVIRONMENT_CAPS -s \$AWS_SECRET_ACCESS_KEY_$ENVIRONMENT_CAPS/g")
 
-nvm ls
+echo "NVM ls:"
+echo $(nvm ls)
 
 echo Running deploy command for "$ENVIRONMENT_NAME" environment:
 echo "  $DEPLOY_CMD"

--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -22,6 +22,8 @@ DEPLOY_CMD=$(cat package.json | jq ".scripts | .\"deploy-$ENVIRONMENT_NAME\"" --
 # known to be set in travis:
 DEPLOY_CMD=$(echo "$DEPLOY_CMD" | sed "s/ --profile [a-z-]*/ -a \$AWS_ACCESS_KEY_ID_$ENVIRONMENT_CAPS -s \$AWS_SECRET_ACCESS_KEY_$ENVIRONMENT_CAPS/g")
 
+nvm ls
+
 echo Running deploy command for "$ENVIRONMENT_NAME" environment:
 echo "  $DEPLOY_CMD"
 

--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -22,9 +22,6 @@ DEPLOY_CMD=$(cat package.json | jq ".scripts | .\"deploy-$ENVIRONMENT_NAME\"" --
 # known to be set in travis:
 DEPLOY_CMD=$(echo "$DEPLOY_CMD" | sed "s/ --profile [a-z-]*/ -a \$AWS_ACCESS_KEY_ID_$ENVIRONMENT_CAPS -s \$AWS_SECRET_ACCESS_KEY_$ENVIRONMENT_CAPS/g")
 
-echo "node version:"
-echo $(node --version)
-
 echo Running deploy command for "$ENVIRONMENT_NAME" environment:
 echo "  $DEPLOY_CMD"
 

--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -22,8 +22,8 @@ DEPLOY_CMD=$(cat package.json | jq ".scripts | .\"deploy-$ENVIRONMENT_NAME\"" --
 # known to be set in travis:
 DEPLOY_CMD=$(echo "$DEPLOY_CMD" | sed "s/ --profile [a-z-]*/ -a \$AWS_ACCESS_KEY_ID_$ENVIRONMENT_CAPS -s \$AWS_SECRET_ACCESS_KEY_$ENVIRONMENT_CAPS/g")
 
-echo "NVM ls:"
-echo $(nvm ls)
+echo "node version:"
+echo $(node --version)
 
 echo Running deploy command for "$ENVIRONMENT_NAME" environment:
 echo "  $DEPLOY_CMD"


### PR DESCRIPTION
This fixes an issue with travis deployment:

Travis respects the Node version specified in `.nvmrc` for tests (see [docs](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/)). That specified node version may not match the default node version used for custom deploy scripts (where, it seems, `.nvmrc` is not automatically read). Thus, Travis uses version 10 for `npm install` at the start of execution , but when it comes time to run the custom deploy script that this app uses, Node falls back to version 8. The `node_modules` directory was built for 10, so it may include syntax that breaks for Node 8. That's what happened here: A module included a line like:

```
try {
...
} catch {
...
}
```

which is valid for Node 10 but not Node 8. (Node 8 needs `catch (e)` even if `e` isn't used.)

The fix is to ensure the deploy section has the correct Node version established before it begins via `nvm install` (which reads `.nvmrc`)

This also adds a fix to the condition for deploying to production, which would have failed as written.